### PR TITLE
ECOM-16875: tolerate unknown branch rule types (copilot_code_review)

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,13 @@
 This is a fork of git@github.com:hub4j/github-api.git
 
 ## How to make release a change
+
+> **⚠️ The instructions below are outdated.** The `public-nexus.ecwid.com` Nexus
+> is no longer used by the main `Ecwid/ecwid` build — artifacts are now consumed
+> from GitHub Packages in [`Ecwid/thirdparty-packages`](https://github.com/Ecwid/thirdparty-packages).
+> See `build-logic/upload-thirdparty-lib/README.md` in the `Ecwid/ecwid` repo
+> for the current publishing workflow. This README needs to be updated.
+
 1. Make a change in the code
 2. Update the version in the `pom.xml` file by incrementing the version number
 3. Ensure it compiles and commit the change

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.kohsuke</groupId>
   <artifactId>github-api</artifactId>
-  <version>1.327-ecwid-11</version>
+  <version>1.327-ecwid-12</version>
   <name>GitHub API for Java</name>
   <url>https://github-api.kohsuke.org/</url>
   <description>GitHub API for Java</description>

--- a/src/main/java/org/kohsuke/github/GHRule.java
+++ b/src/main/java/org/kohsuke/github/GHRule.java
@@ -1,5 +1,7 @@
 package org.kohsuke.github;
 
+import com.fasterxml.jackson.annotation.JsonEnumDefaultValue;
+
 import java.util.Collection;
 
 public class GHRule {
@@ -29,6 +31,7 @@ public class GHRule {
 
 	public enum RuleType {
 		commit_author_email_pattern,
+		copilot_code_review,
 		creation,
 		deletion,
 		merge_queue,
@@ -40,6 +43,13 @@ public class GHRule {
 		required_signatures,
 		required_status_checks,
 		update,
+
+		// Fallback for any rule type GitHub introduces in the future that this client
+		// does not yet know about. Combined with READ_UNKNOWN_ENUM_VALUES_USING_DEFAULT_VALUE
+		// in GitHubClient's ObjectMapper, this prevents deserialization failures on
+		// new rule types and lets callers safely ignore them.
+		@JsonEnumDefaultValue
+		unknown,
 	}
 
 	public static class Parameters {

--- a/src/main/java/org/kohsuke/github/GitHubClient.java
+++ b/src/main/java/org/kohsuke/github/GitHubClient.java
@@ -88,6 +88,7 @@ class GitHubClient {
     static {
         MAPPER.setVisibility(new VisibilityChecker.Std(NONE, NONE, NONE, NONE, ANY));
         MAPPER.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+        MAPPER.configure(DeserializationFeature.READ_UNKNOWN_ENUM_VALUES_USING_DEFAULT_VALUE, true);
         MAPPER.configure(MapperFeature.ACCEPT_CASE_INSENSITIVE_ENUMS, true);
         MAPPER.setPropertyNamingStrategy(PropertyNamingStrategy.SNAKE_CASE);
     }


### PR DESCRIPTION
  ## Summary
  GitHub Copilot Code Review was enabled on `Ecwid/ecwid` and added a new branch ruleset rule of type `copilot_code_review`. The current `RuleType` enum doesn't know about it, so Jackson fails the whole response of `GET /repos/{owner}/{repo}/rules/branches/{branch}` 
  with `InvalidFormatException` — blocking releases end-to-end (`enqueue-to-release` and `check-bypassing` tools).
  See [ECOM-16875](https://lightspeedhq.atlassian.net/browse/ECOM-16875).
  ## Changes
  - `GHRule.RuleType`: add `copilot_code_review` and a terminal `unknown` constant marked with `@JsonEnumDefaultValue` as a safety net for any future rule type GitHub introduces.
  - `GitHubClient`: enable `DeserializationFeature.READ_UNKNOWN_ENUM_VALUES_USING_DEFAULT_VALUE` on the singleton `ObjectMapper` so `@JsonEnumDefaultValue` actually fires.
  - `pom.xml`: bump version to `1.327-ecwid-12`.
  - `README.md`: add a note that the publishing instructions are outdated (the `public-nexus.ecwid.com` Nexus is no longer used; current workflow lives at `Ecwid/ecwid/build-logic/upload-thirdparty-lib`).
  This mirrors the pattern upstream `hub4j` adopted in 1.330+ (`EnumUtils.getEnumOrDefault(..., Type.UNKNOWN)`), but as a minimal backport on top of our 1.327 fork.
  ## Test plan
  - [x] `mvn compile` — passes.
  - [x] Local unit test verified: known types still map correctly; `copilot_code_review` maps to its dedicated constant; arbitrary unknown future types fall back to `RuleType.unknown`; mixed array (the exact shape from the failing GH response) deserializes fully without
   exception; `null` stays `null`.
  - [ ] After merge: build jar, upload `1.327-ecwid-12` to `Ecwid/thirdparty-packages`, then bump `Versions.githubApi` and tool versions in `Ecwid/ecwid` (separate PR).
